### PR TITLE
Fix Flaky Test

### DIFF
--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -18,6 +18,10 @@ class CardsTests(N26TestBase):
     @mock_requests(method=POST, response_file="card_block_single.json")
     def test_block_card_cli_single(self):
         from n26.cli import card_block
+        card_id_1 = '12345678-1234-abcd-abcd-1234567890ab'
+        card_id_2 = '22345678-1234-abcd-abcd-1234567890ab'
+        result = self._run_cli_cmd(card_block)
+        from n26.cli import card_block
         card_id = "12345678-1234-abcd-abcd-1234567890ab"
         result = self._run_cli_cmd(card_block, ["--card", card_id])
         self.assertEqual(result.output, "Blocked card: {}\n".format(card_id))
@@ -25,6 +29,8 @@ class CardsTests(N26TestBase):
     @mock_requests(method=GET, response_file="cards.json")
     @mock_requests(method=POST, response_file="card_block_single.json")
     def test_block_card_cli_all(self):
+        from n26.cli import cards
+        result = self._run_cli_cmd(cards)
         from n26.cli import card_block
         card_id_1 = "12345678-1234-abcd-abcd-1234567890ab"
         card_id_2 = "22345678-1234-abcd-abcd-1234567890ab"
@@ -35,6 +41,10 @@ class CardsTests(N26TestBase):
     @mock_requests(method=GET, response_file="cards.json")
     @mock_requests(method=POST, response_file="card_unblock_single.json")
     def test_unblock_card_cli_single(self):
+        from n26.cli import card_block
+        card_id_1 = '12345678-1234-abcd-abcd-1234567890ab'
+        card_id_2 = '22345678-1234-abcd-abcd-1234567890ab'
+        result = self._run_cli_cmd(card_block)
         from n26.cli import card_unblock
         card_id = "12345678-1234-abcd-abcd-1234567890ab"
         result = self._run_cli_cmd(card_unblock, ["--card", card_id])


### PR DESCRIPTION
<h2>What is the purpose of this PR</h2>

- This PR patches 3 tests and prevents them from failing when they are run by themselves.
- The tests are flaky (non-deterministic) and depend on another test to set up a state to pass, but the tests fail when they are run by themselves otherwise
- For example: `tests/test_cards.py::CardsTests::test_block_card_cli_all` depends on `tests/test_cards.py::CardsTests::test_cards_cli` to pass

---

<h2>Expected Result</h2> 

- Test `tests/test_cards.py::CardsTests::test_block_card_cli_all` should pass when run both by itself and after `tests/test_cards.py::CardsTests::test_cards_cli`

---
<h2>Actual Result</h2> 

- Test `tests/test_cards.py::CardsTests::test_block_card_cli_all`  fails when it is run by itself

---

<h2>Reproduce the test failure</h2>

- Run `python3 -m pytest tests/test_cards.py::CardsTests::test_block_card_cli_all` 

---
<h2>Why the Test Fails</h2> 

- The test fails because the test is dependent on some state that is not set when it is run by itself. 

---
<h2>Fix</h2>

- The changes in this pull request sets the state for 3 flaky tests and make the tests pass when they are run by themselves. 

---

